### PR TITLE
Launch hotfixes

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -246,6 +246,10 @@ body {
 	}
 }
 
+.content--no-sidebar {
+  display: block;
+}
+
 /** Posts **/
 
 .post {
@@ -280,6 +284,10 @@ body {
 	}
 	}
 
+}
+
+.post--wide {
+  padding: 0;
 }
 
 .post hr {

--- a/css/site.css
+++ b/css/site.css
@@ -687,9 +687,10 @@ ul.list-inline {
 }
 
 .sidebar ul li {
-	list-style-type: none;
 	list-style-image: none;
+	list-style-type: none;
 	margin-bottom: 15px;
+  clear:both;
 }
 
 .sidebar ul p,

--- a/functions/posts.php
+++ b/functions/posts.php
@@ -5,9 +5,8 @@
  * @package LHXC
  */
 
-/** Add thumbnails */
+/** Add thumbnails - Paste this where you wanna use it - the_post_thumbnail(); */
 add_theme_support( 'post-thumbnails' );
-/** Paste this where you wanna use it - the_post_thumbnail(); */
 
 /**
  * Add odd or even post classes to the post for zebra striping.
@@ -30,9 +29,7 @@ $current_class = 'odd';
 function lhxc_default_featured_image() {
 	if ( ! has_post_thumbnail() ) {
 		$default_image_url = get_default_feature_image();
-		/** Get the attachment ID of the default image */
-		$default_image_id = attachment_url_to_postid( $default_image_url );
-		/** Set the default image as the featured image */
+		$default_image_id  = attachment_url_to_postid( $default_image_url );
 		set_post_thumbnail( get_the_ID(), $default_image_id );
 	}
 }
@@ -42,8 +39,6 @@ add_action( 'save_post', 'lhxc_default_featured_image' );
  * Set a default feature image
  */
 function set_default_featured_image_for_existing_posts() {
-	/** Replace 'your_default_image_url' with the URL of your default featured image */
-	// $default_image_url = 'https://www.louisvillehardcore.com/wp-content/uploads/2024/02/52986395372_1f08e95b33_c.jpg';
 	$default_image_url = get_default_feature_image();
 
 	/** Get the attachment ID of the default image */
@@ -51,15 +46,14 @@ function set_default_featured_image_for_existing_posts() {
 
 	/** Query to retrieve posts and pages that do not have a featured image set */
 	$args = array(
-		'post_type'              => array( 'post', 'page' ),
-		/** You can include additional post types if needed */
-					'meta_query' => array(
-						array(
-							'key'     => '_thumbnail_id',
-							'compare' => 'NOT EXISTS',
-						),
-					),
-		'posts_per_page'         => -1,
+		'post_type'      => array( 'post', 'page' ),
+		'meta_query'     => array(
+			array(
+				'key'     => '_thumbnail_id',
+				'compare' => 'NOT EXISTS',
+			),
+		),
+		'posts_per_page' => -1,
 	);
 
 	$query = new WP_Query( $args );

--- a/functions/posts.php
+++ b/functions/posts.php
@@ -44,7 +44,7 @@ add_action( 'save_post', 'lhxc_default_featured_image' );
 function set_default_featured_image_for_existing_posts() {
 	/** Replace 'your_default_image_url' with the URL of your default featured image */
 	// $default_image_url = 'https://www.louisvillehardcore.com/wp-content/uploads/2024/02/52986395372_1f08e95b33_c.jpg';
-  $default_image_url = get_default_feature_image();
+	$default_image_url = get_default_feature_image();
 
 	/** Get the attachment ID of the default image */
 	$default_image_id = attachment_url_to_postid( $default_image_url );

--- a/functions/posts.php
+++ b/functions/posts.php
@@ -42,8 +42,12 @@ add_action( 'save_post', 'lhxc_default_featured_image' );
  * Set a default feature image
  */
 function set_default_featured_image_for_existing_posts() {
+	/** Replace 'your_default_image_url' with the URL of your default featured image */
+	// $default_image_url = 'https://www.louisvillehardcore.com/wp-content/uploads/2024/02/52986395372_1f08e95b33_c.jpg';
+  $default_image_url = get_default_feature_image();
+
 	/** Get the attachment ID of the default image */
-	$default_image_id = attachment_url_to_postid( get_default_feature_image() );
+	$default_image_id = attachment_url_to_postid( $default_image_url );
 
 	/** Query to retrieve posts and pages that do not have a featured image set */
 	$args = array(

--- a/functions/posts.php
+++ b/functions/posts.php
@@ -42,11 +42,8 @@ add_action( 'save_post', 'lhxc_default_featured_image' );
  * Set a default feature image
  */
 function set_default_featured_image_for_existing_posts() {
-	/** Replace 'your_default_image_url' with the URL of your default featured image */
-	$default_image_url = 'https://www.louisvillehardcore.com/wp-content/uploads/2024/02/52986395372_1f08e95b33_c.jpg';
-
 	/** Get the attachment ID of the default image */
-	$default_image_id = attachment_url_to_postid( $default_image_url );
+	$default_image_id = attachment_url_to_postid( get_default_feature_image() );
 
 	/** Query to retrieve posts and pages that do not have a featured image set */
 	$args = array(

--- a/page-full-width.php
+++ b/page-full-width.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ *  * Template Name: Full Width Page
+ *
+ * @package LHXC
+ * @subpackage Default_Theme
+ */
+
+get_header();?>
+</div><!-- .page-wrapper -->
+
+<main id="content" class="content page content--no-sidebar">
+
+		<div class="page-main-content">
+		<?php
+		if ( have_posts() ) :
+			while ( have_posts() ) :
+				the_post();
+				?>
+						<div class="post post--wide" id="post-<?php the_ID(); ?>">
+							<h1><?php the_title(); ?></h1>
+								<div class="entry">
+									<?php the_content( '<p class="serif">Read the rest of this page &raquo;</p>' ); ?>
+
+									<?php
+									wp_link_pages(
+										array(
+											'before' => '<p><strong>Pages:</strong> ',
+											'after'  => '</p>',
+											'next_or_number' => 'number',
+										)
+									);
+									?>
+
+								</div>
+							</div>
+									<?php
+						endwhile;
+endif;
+		?>
+	<?php edit_post_link( 'Edit this entry.', '<p>', '</p>' ); ?>
+
+</div><!-- /.page-main-content -->
+
+</main>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
Continuing updates:

- Add full width template page support
- Fix incorrect default feature image, now uses global feature image method
- Fix sidebar rendering issue after floated feature images